### PR TITLE
Persist data with localStorage

### DIFF
--- a/src/public/stores/index.ts
+++ b/src/public/stores/index.ts
@@ -1,4 +1,5 @@
-import { readable, writable } from 'svelte/store';
+import { readable } from 'svelte/store';
+import { persistable } from './persistable';
 
 export const starting_text = readable(
 	// "var boxB = Game.Bodies.rectangle(200, 200, 300, 300)\nfunction setup() { // runs once at start\n  console.log('hi')\n  Game.addObject(boxB)\n}\n\nfunction draw() { // runs every frame\n  console.log('drawing')\n}"
@@ -37,9 +38,11 @@ function draw() {
 `
 );
 
-export const editor_text = writable('');
+const editor_text_key = '__editor_text';
+export const editor_text = persistable(editor_text_key, '');
 
-export const game_view = writable('left');
+const game_view_key = '__game_view';
+export const game_view = persistable(game_view_key, 'left');
 
 // export const starting_text = readable(
 // 	`

--- a/src/public/stores/persistable.ts
+++ b/src/public/stores/persistable.ts
@@ -1,0 +1,57 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Creates a persistable svelte store that uses localStorage to persist data
+ * @param {string} key - The key to store the value in localStorage
+ * @param {T} initialValue - The initial value of the store
+ * @returns {writable<T>} - A writable store with added functionality to persist the data
+ * @template T
+ */
+export function persistable<T>(key: string, initialValue: T) {
+	let value = initialValue;
+	try {
+		const storedValue = localStorage.getItem(key);
+		if (storedValue !== null) {
+			value = JSON.parse(storedValue);
+		}
+	} catch (err) {
+		console.error('Error reading from localStorage', err);
+	}
+
+	const store = writable<T>(value);
+
+	const subscribe = store.subscribe;
+
+	/**
+	 * set the value of the store and persist it in localStorage
+	 * @param {T} newValue - The new value of the store
+	 */
+	store.set = (newValue: T) => {
+		try {
+			localStorage.setItem(key, JSON.stringify(newValue));
+		} catch (err) {
+			console.error('Error writing to localStorage', err);
+		}
+		store.set(newValue);
+	};
+
+	/**
+	 * Update the value of the store and persist it in localStorage
+	 * @param {(value: T) => T} fn - The update function
+	 */
+	store.update = (fn: (value: T) => T) => {
+		const newValue = fn(value);
+		store.set(newValue);
+	};
+
+	/**
+	 * subscribe to the store and receive the current value
+	 * @param {(value: T) => void} run - The callback function
+	 */
+	store.subscribe = (run: (value: T) => void) =>
+		subscribe((value) => {
+			run(value);
+		});
+
+	return store;
+}


### PR DESCRIPTION
Persist editor text and game view in [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) via new `persistable` Svelte store.